### PR TITLE
Can now pass a string via command prompt

### DIFF
--- a/src/WordscapesCheat.CLI/Program.cs
+++ b/src/WordscapesCheat.CLI/Program.cs
@@ -11,7 +11,7 @@ namespace WordscapesCheat.CLI
     {        
         static void Main(string[] args)
         {
-            string characterSet = "penis";
+            string characterSet = CheatFunctions.ConvertStringArrayToString(args);
             List<string> dictionary = CheatFunctions.GetDictionary();
             
             PrintMatchingWords(CheatFunctions.BuildMatchingWordsArray(characterSet, dictionary));

--- a/src/WordscapesCheat/CheatFunctions.cs
+++ b/src/WordscapesCheat/CheatFunctions.cs
@@ -18,6 +18,18 @@ namespace WordscapesCheat
                 .ToList();
         }
 
+        public static string ConvertStringArrayToString(string[] array)
+        {   // KC - I took the below from a URL: "https://www.dotnetperls.com/convert-string-array-string"
+
+            // Concatenate all the elements into a StringBuilder.
+            StringBuilder builder = new StringBuilder();
+            foreach (string value in array)
+            {
+                builder.Append(value);
+            }
+            return builder.ToString();
+        }
+
         public static int[] BuildOccurenceArray(string inputString)
         {
             const int A_ASCII = 97;


### PR DESCRIPTION
I created a method that converts a string array to a string, and then made sure that args are passed.

Now when I run in command prompt and pass a string, it then displays all matching words.

I can imagine a bug where if you don't pass a-z letters it has a fit, so I should create an issue for that after testing, but this has solved issue #18.